### PR TITLE
Adding Github URL so link shows on Expo page

### DIFF
--- a/app.json
+++ b/app.json
@@ -7,6 +7,7 @@
     "version": "1.0.0",
     "orientation": "portrait",
     "platforms": ["ios", "android"],
+    "githubUrl":"https://github.com/brentvatne/growler-prowler",
     "primaryColor": "#f6bd94",
     "privacy": "unlisted",
     "icon": "./icon.png",


### PR DESCRIPTION
Adding this field enables a Github link from the expo app page